### PR TITLE
Set minimum dappnode version

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -28,7 +28,7 @@
   },
   "license": "GPL-3.0",
   "requirements": {
-    "minimumDappnodeVersion": "0.2.51"
+    "minimumDappnodeVersion": "0.2.56"
   },
   "chain": {
     "driver": "ethereum-beacon-chain",


### PR DESCRIPTION
Set the requirement to have the core release 0.2.56 to install lighthouse gnosis