### PR TITLE
Back to the previous version

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "lighthouse-gnosis.dnp.dappnode.eth",
   "version": "0.1.0",
-  "upstreamVersion": "v3.1.2",
+  "upstreamVersion": "v3.1.0",
   "architectures": ["linux/amd64"],
   "upstreamRepo": "sigp/lighthouse",
   "shortDescription": "Lighthouse Gnosis Chain CL Beacon chain + validator",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: v3.1.2
+        UPSTREAM_VERSION: v3.1.0
     volumes:
       - "beacon-data:/root/.lighthouse"
     ports:


### PR DESCRIPTION
There are some problem with lighthouse for this gnosis chain. We are researching what can provoke this errors.

The validator service is stuck on 
```
Sep 29 14:44:07.501 INFO Awaiting activation                     slot: 5093861, epoch: 318366, validators: 4, service: notifier
```
And after a while, the container is restarted:
```
Sep 29 14:44:07.501 INFO Awaiting activation                     slot: 5093861, epoch: 318366, validators: 4, service: notifier
Sep 29 14:44:08.752 CRIT Doppelganger(s) detected                doppelganger_indices: {57804}, msg: A doppelganger occurs when two different validator clients run the same public key. This validator client detected another instance of a local validator on the network and is shutting down to prevent potential slashable offences. Ensure that you are not running a duplicate or overlapping validator client, service: doppelganger
Sep 29 14:44:08.752 INFO Internal shutdown received              reason: Doppelganger detected.
Sep 29 14:44:08.752 INFO Shutting down..                         reason: Failure("Doppelganger detected.")
Doppelganger detected.
```