### PR TITLE
Remove slash from the url

### DIFF
--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -27,7 +27,7 @@ fields:
     title: Checkpoint for fast sync
     description: >-
       To get Lighthouse up and running in only a few minutes, you can start Lighthouse from a recent finalized checkpoint state rather than syncing from genesis. This is substantially **faster** and consumes **less resources** than syncing from genesis, while still providing all the same features. Be sure you are using a trusted node for the fast sync.
-      Get your checkpoint sync from a running gnosis beacon chain node or use the official one **https://rpc-gbc.gnosischain.com/**
+      Get your checkpoint sync from a running gnosis beacon chain node or use the official one **https://rpc-gbc.gnosischain.com**
     required: false
   - id: feeRecipientAddress
     target:


### PR DESCRIPTION
With the slash the rpc endpoint does not work