### PR TITLE
fix: erigon http engine

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -8,7 +8,7 @@ case $_DAPPNODE_GLOBAL_EXECUTION_CLIENT_GNOSIS in
   HTTP_ENGINE="http://nethermind-xdai.dappnode:8551"
   ;;
 "gnosis-erigon.dnp.dappnode.eth")
-    HTTP_ENGINE="http://gnosis-erigon.dappnode:8551"
+  HTTP_ENGINE="http://gnosis-erigon.dappnode:8551"
   ;;
 *)
   echo "Unknown value for _DAPPNODE_GLOBAL_EXECUTION_CLIENT_GNOSIS: $_DAPPNODE_GLOBAL_EXECUTION_CLIENT_GNOSIS"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,40 +1,40 @@
 version: "3.4"
 services:
   beacon-chain:
-    image: "beacon-chain.lighthouse-gnosis.dnp.dappnode.eth:0.1.0"
+    image: beacon-chain.lighthouse-gnosis.dnp.dappnode.eth:0.1.12
     build:
       context: beacon-chain
       args:
         UPSTREAM_VERSION: v5.1.0
     volumes:
-      - "beacon-data:/root/.lighthouse"
+      - beacon-data:/root/.lighthouse
     ports:
-      - "19004:19004/tcp"
-      - "19004:19004/udp"
+      - 19004:19004/tcp
+      - 19004:19004/udp
     restart: unless-stopped
     security_opt:
-      - "seccomp:unconfined"
+      - seccomp:unconfined
     environment:
       DEBUG_LEVEL: info
       BEACON_API_PORT: 3500
-      CORSDOMAIN: "http://lighthouse-gnosis.dappnode"
+      CORSDOMAIN: http://lighthouse-gnosis.dappnode
       CHECKPOINT_SYNC_URL: ""
       EXTRA_OPTS: ""
       P2P_PORT: 19004
       HTTP_ENGINE: ""
   validator:
-    image: "validator.lighthouse-gnosis.dnp.dappnode.eth:0.1.0"
+    image: validator.lighthouse-gnosis.dnp.dappnode.eth:0.1.12
     build:
       context: validator
       args:
         UPSTREAM_VERSION: v5.1.0
     restart: unless-stopped
     security_opt:
-      - "seccomp:unconfined"
+      - seccomp:unconfined
     environment:
       DEBUG_LEVEL: info
-      HTTP_WEB3SIGNER: "http://web3signer.web3signer-gnosis.dappnode:9000"
-      BEACON_NODE_ADDR: "http://beacon-chain.lighthouse-gnosis.dappnode:3500"
+      HTTP_WEB3SIGNER: http://web3signer.web3signer-gnosis.dappnode:9000
+      BEACON_NODE_ADDR: http://beacon-chain.lighthouse-gnosis.dappnode:3500
       GRAFFITI: validating_from_DAppNode
       EXTRA_OPTS: ""
       FEE_RECIPIENT_ADDRESS: ""

--- a/releases.json
+++ b/releases.json
@@ -4,5 +4,11 @@
     "uploadedTo": {
       "dappnode": "Fri, 03 Dec 2021 21:37:59 GMT"
     }
+  },
+  "0.1.12": {
+    "hash": "/ipfs/QmVsyMq6hWNnY74corh9dQQhw86vDqtqmNcuPLP6ux6pcz",
+    "uploadedTo": {
+      "dappnode": "Sat, 11 May 2024 13:17:52 GMT"
+    }
   }
 }


### PR DESCRIPTION
This PR fix the same problem with EL `HTTP_ENGINE` spacing in `entrypoint.sh` as was described in https://github.com/dappnode/DAppNodePackage-teku-gnosis/pull/90